### PR TITLE
fix(git): allow the command to pass on windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ function gitRawCommits(options) {
   });
 
   var cmd = template(
-    'git log --format=\'<%= format %>%n------------------------ >8 ------------------------\' ' +
+    'git log --format=\"<%= format %>%n------------------------ >8 ------------------------\" ' +
     '<%= from ? [from, to].join("..") : to %> '
   )(options) + args.join(' ');
 

--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ function gitRawCommits(options) {
 
   var cmd = template(
     'git log --format=\"<%= format %>%n------------------------ >8 ------------------------\" ' +
-    '<%= from ? [from, to].join("..") : to %> '
+    '\"<%- from ? [from, to].join("..") : to %>\" '
   )(options) + args.join(' ');
 
   var anything = false;

--- a/test.js
+++ b/test.js
@@ -23,7 +23,7 @@ it('should emit an error if there is no commits', function(done) {
     }));
 });
 
-it('should get commits without `options` (`options.from` defaults to first commit)', function(done) {
+it('should execute the command without error', function(done) {
   writeFileSync('test1', '');
   shell.exec('git add --all && git commit -m"First commit"');
   writeFileSync('test2', '');
@@ -31,6 +31,20 @@ it('should get commits without `options` (`options.from` defaults to first commi
   writeFileSync('test3', '');
   shell.exec('git add --all && git commit -m"Third commit"');
 
+  var called = false;
+  var callback = function(err) {
+    if (!called) {
+      called = true;
+      done(err);
+    }
+  };
+
+  gitRawCommits()
+    .on('close', callback)
+    .on('error', callback);
+});
+
+it('should get commits without `options` (`options.from` defaults to first commit)', function(done) {
   var i = 0;
 
   gitRawCommits()


### PR DESCRIPTION
When a command has spaces in windows, it seems that it doesn't consider spaces as part of the string unless it's wrapped in double-quote `"`.

Single-quotes `'` are not considered a string.