### PR TITLE
fix(windows): use execFile for executing git

### DIFF
--- a/test.js
+++ b/test.js
@@ -132,8 +132,35 @@ it('should show your git-log command', function(done) {
   gitRawCommits({
     format: 'what%n%B',
     debug: function(cmd) {
-      expect(cmd).to.equal('Your git-log command is:\ngit log --format="what%n%B%n------------------------ >8 ------------------------" "HEAD" ');
+      expect(cmd).to.equal('Your git-log command is:\ngit log --format=what%n%B%n------------------------ >8 ------------------------ HEAD');
       done();
     }
   });
 });
+
+if (process.platform === 'win32') {
+  it('should prevent variable expansion on windows', function(done) {
+    var i = 0;
+
+    gitRawCommits({
+      format: '%%cd%n%B'
+    })
+      .pipe(through(function(chunk, enc, cb) {
+        chunk = chunk.toString();
+
+        if (i === 0) {
+          expect(chunk).to.equal('%cd\nThird commit\n\n');
+        } else if (i === 1) {
+          expect(chunk).to.equal('%cd\nSecond commit\n\n');
+        }else {
+          expect(chunk).to.equal('%cd\nFirst commit\n\n');
+        }
+
+        i++;
+        cb();
+      }, function() {
+        expect(i).to.equal(3);
+        done();
+      }));
+  });
+}


### PR DESCRIPTION
Fix problems with variable expansion and escaping by passing arguments straight to git with execFile instead of going through a shell to execute it.

So unfortunately the last fix didn't work.. This fix is much better anyways. It uses `child_process.execFile` instead of `exec` to directly pass arguments to the `git` executable. This way the arguments never pass through `cmd` or `shell` and variable expansion becomes a non-problem. There's also a test for the windows variable expansion included. [Tests pass with this fix.](https://ci.appveyor.com/project/Tapppi/git-raw-commits/build/job/eifv2grubbkv7dv2)

[Stack overflow question describing the problem and a good answer that led to this fix](http://stackoverflow.com/questions/33016094/is-there-a-way-to-prevent-percent-expansion-of-env-variable-in-windows-command-l)
